### PR TITLE
Adds making dropout after flatten optional

### DIFF
--- a/BlueSTARR-multitask.py
+++ b/BlueSTARR-multitask.py
@@ -379,7 +379,7 @@ def BuildModel(seqlen):
         x = Flatten()(x) # Commented out on 3/22/2023
 
     # dense layers
-    if(config.NumDense>0):
+    if((config.NumDense>0) and config.PreDenseDropout):
         x=Dropout(config.DropoutRate)(x)
     for i in range(config.NumDense):
         x=kl.Dense(config.DenseSizes[i])(x)

--- a/K562.config
+++ b/K562.config
@@ -24,6 +24,7 @@ GlobalMaxPool = 0
 GlobalAvePool = 1
 NumDense = 0
 DenseSizes = 0
+PreDenseDropout = 1
 NumAttentionLayers = 0
 AttentionHeads = 0
 AttentionKeyDim = 0

--- a/NeuralConfig.py
+++ b/NeuralConfig.py
@@ -128,8 +128,12 @@ class NeuralConfig:
 #=========================================================================
 # main()
 #=========================================================================
-#if(len(sys.argv)!=2):
-#    exit(ProgramName.get()+" <in.config>\n")
-#(infile,)=sys.argv[1:]
-#config=NeuralConfig(infile)
-#config.dump()
+def main():
+    if(len(sys.argv)!=2):
+        exit(ProgramName.get()+" <in.config>\n")
+    (infile,)=sys.argv[1:]
+    config=NeuralConfig(infile)
+    config.dump()
+
+if __name__ == "__main__":
+    main()

--- a/NeuralConfig.py
+++ b/NeuralConfig.py
@@ -72,6 +72,9 @@ class NeuralConfig:
         self.NumDense=int(config.lookupOrDie("NumDense"))
         self.DenseSizes=[int(x) for x in config.lookupListOrDie("DenseSizes")]
         self.checkSize("DenseSizes",self.DenseSizes,self.NumDense)
+        self.PreDenseDropout=config.lookup("PreDenseDropout")
+        if(self.PreDenseDropout is None): self.PreDenseDropout=1 # defaults to true!
+        else: self.PreDenseDropout=int(self.PreDenseDropout)
 
         # Parameters pertaining to output and loss
         self.Tasks=config.lookupList("Tasks")
@@ -120,7 +123,8 @@ class NeuralConfig:
         print("DropoutRate=",self.DropoutRate,sep="")
         print("LearningRate=",self.LearningRate,sep="")
         print("ConvDropout=",self.ConvDropout,sep="")
-        
+        print("PreDenseDropout=",self.PreDenseDropout,sep="")
+
 #=========================================================================
 # main()
 #=========================================================================


### PR DESCRIPTION
This is to mirror the architecture of DeepSTARR, which uses a Flatten step with subsequent Dense layers, but does not put a dropout layer between these.

Also adds clean logic for calling as a program, which is mainly useful for testing a given configuration file for its contents and syntax (such as the one included in this PR).