### PR TITLE
Updates transformer-based model architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ BlueSTARR: predicting effects of regulatory variants
 1. Create a new conda environment with Python 3.10. (Later versions may work but have not been tested.)
    ```bash
    # you can also use -n YourEnvName instead of -p /path/to/env
-   conda create -p /path/to/new/conda/env -c conda-forge python=3.10
+   conda create -p /path/to/new/conda/env -c conda-forge python=3.11
    ```
 2. Activate the conda environment you just created:
    ```bash


### PR DESCRIPTION
Changes from SinePositionEncoding to RotaryEncoding, and changes the transformer layer to use TransformerEncoder from keras_nlp, rather than MultiHeadAttention.

Also upgrades the recommended Python version to 3.11 (from 3.10).